### PR TITLE
Basic support for Ltac2 Backtrace / Ltac Profiling

### DIFF
--- a/src/tac2compile.ml
+++ b/src/tac2compile.ml
@@ -898,7 +898,9 @@ let pp_one_constant (kn, knid, na, bnd, e) =
     | Fun (nas, e) ->
       hv 2
         (str "let " ++ h (str na ++ pp_binders nas) ++ str " =" ++ spc() ++
-         pp_expr e) ++ fnl() ++ fnl()
+         hov 2
+           (str "Tac2bt.with_frame (FrLtac " ++ SpilledKn.print knid ++ str ")"
+            ++ spc() ++ surround (pp_expr e))) ++ fnl() ++ fnl()
     | _ -> hv 2 (str "let " ++ str na ++ str " =" ++ spc() ++ pp_nontac_expr e) ++ fnl() ++ fnl()
   in
   let pp_set_compiled =


### PR DESCRIPTION
On bug_10107.v:
- before this PR 0.037s
- after this PR 0.043s
- enable Ltac2 Backtrace 0.2s
- enable Ltac Profiling 3s
- without compiling 0.25s
- Ltac2 Backtrace without compiling 1s
- Ltac Profiling without compiling 30s

Note that this implementation only puts the FrLtac frames, not the ones of anon functions.

This is especially impactful for recursion as `Ltac2 rec bla binders := ...` becomes `Ltac2 bla binders := let rec bla binders := ... in bla binders` so only the top call gets a frame, and with profiling only the top call produces overhead.

We should expect that adding frames for anonymous functions / recursive calls would be significantly worse than the current results.