### PR TITLE
Monad-thunk every nontrivial nontac_expr

### DIFF
--- a/tests/Makefile.coq.local
+++ b/tests/Makefile.coq.local
@@ -1,0 +1,1 @@
+CAMLPKGS:=-package coq-core.plugins.ltac2

--- a/tests/_CoqProject
+++ b/tests/_CoqProject
@@ -9,3 +9,10 @@ minibench.v
 compiler_bug_4.v
 compiler_bug_6.v
 compiler_bug_14.v
+compiler_bug_17.v
+
+-I src
+
+src/META.compiler-bugs
+src/compiler_bug_17.ml
+src/compiler_bug_17_plugin.mlpack

--- a/tests/compiler_bug_17.v
+++ b/tests/compiler_bug_17.v
@@ -1,0 +1,21 @@
+From Ltac2 Require Import Ltac2 Printf.
+
+From Ltac2Compiler Require Import Ltac2Compiler.
+
+Declare ML Module "compiler-bugs.compiler_bug_17".
+
+Ltac2 @ external push : unit -> int := "compiler-bugs.compiler_bug_17" "push".
+Ltac2 @ external pop : int -> unit := "compiler-bugs.compiler_bug_17" "pop".
+Ltac2 @ external reset : unit -> unit := "compiler-bugs.compiler_bug_17" "reset".
+
+Ltac2 test2 () :=
+  let outer := push () in
+  let inner := push () in
+  ltac1:(assert False) >
+          [pop inner; pop outer|let outer := push () in pop outer].
+
+Ltac2 Compile test2.
+
+Goal True /\ True.
+  test2 ().
+Abort.

--- a/tests/src/META.compiler-bugs
+++ b/tests/src/META.compiler-bugs
@@ -1,0 +1,10 @@
+package "compiler_bug_17" (
+    directory = "."
+    version = "dev"
+    requires = "coq-core.plugins.ltac2"
+    archive(byte) = "compiler_bug_17_plugin.cma"
+    archive(native) = "compiler_bug_17_plugin.cmxa"
+    plugin(byte) = "compiler_bug_17_plugin.cma"
+    plugin(native) = "compiler_bug_17_plugin.cmxs"
+)
+directory = "."

--- a/tests/src/compiler_bug_17.ml
+++ b/tests/src/compiler_bug_17.ml
@@ -1,0 +1,20 @@
+open Ltac2_plugin
+open Tac2ffi
+open Tac2expr
+open Tac2externals
+
+let define s = define { mltac_plugin = "compiler-bugs.compiler_bug_17"; mltac_tactic = s }
+
+let state : int ref = Summary.ref ~name:"tac2compile_bug17" 0
+let push  : unit -> int  = fun () ->
+  state := 1 + !state; !state
+let pop   : int -> unit  = fun i ->
+  if i == !state then
+    state := i - 1
+  else
+    raise Not_found
+let reset : unit -> unit = fun _ -> state := 0
+
+let _ = define "push"  (unit @-> ret int) push
+let _ = define "pop"   (int @-> ret unit) pop
+let _ = define "reset" (unit @-> ret unit) reset

--- a/tests/src/compiler_bug_17_plugin.mlpack
+++ b/tests/src/compiler_bug_17_plugin.mlpack
@@ -1,0 +1,1 @@
+Compiler_bug_17


### PR DESCRIPTION
Fix #17

I am not fully sure that this is a compiler bug as the ~~~ocaml
  let l = List.map (fun f -> Proofview.tclIGNORE (thaw f)) l in
~~~
in the implementation of `dispatch` could also be blamed for not thunking properly (ie should be
~~~ocaml
  let l = List.map (fun f -> tclUNIT () >>= fun () -> tclIGNORE (thaw f)) l in
~~~
) but it does seem hard or impossible to trigger a bug with non compiled ltac2.

This change does cause some slowdown (bug_10107 goes from 0.04s to 0.06s, non compiled baseline being 0.25s)