### PR TITLE
Adapt to rocq-prover/rocq#20566 (Ltac2 rec doesn't produce a wrapper lambda)

### DIFF
--- a/src/tac2compiledPrim.ml
+++ b/src/tac2compiledPrim.ml
@@ -16,7 +16,7 @@ open Proofview.Notations
 
 let core_prefix path n = KerName.make path (Label.of_id (Id.of_string_soft n))
 
-let coq_core n = core_prefix Tac2env.coq_prefix n
+let coq_core n = core_prefix Tac2env.rocq_prefix n
 
 let err_outofbounds =
   Tac2interp.LtacError (coq_core "Out_of_bounds", [||])

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,7 +5,7 @@ submake: Makefile.coq
 	$(MAKE) $(MAKE_OPTS) -f Makefile.coq $(MAKECMDGOALS)
 
 Makefile.coq: _CoqProject
-	$(COQBIN)coq_makefile -f $< -o $@
+	$(COQBIN)coq_makefile -f $< -o $@ $(wildcard *.v)
 
 %:: submake ;
 

--- a/tests/_CoqProject
+++ b/tests/_CoqProject
@@ -3,16 +3,6 @@
 
 -R . Test
 
-tac2compile_test.v
-bug_10107.v
-minibench.v
-compiler_bug_4.v
-compiler_bug_6.v
-compiler_bug_14.v
-compiler_bug_16.v
-compiler_bug_17.v
-compiler_bug_24.v
-
 -I src
 
 src/META.compiler-bugs

--- a/tests/bug_10107.v
+++ b/tests/bug_10107.v
@@ -17,7 +17,7 @@ Ltac2 rec iter tac ls :=
 
 Ltac2 rec find (id : ident) (term : constr) :=
   match Constr.Unsafe.kind term with
-  | Constr.Unsafe.Cast c cst ty => find id c; find id ty
+  | Constr.Unsafe.Cast c _cst ty => find id c; find id ty
   | Constr.Unsafe.App f xs => find id f; Array.iter (find id) xs
   | _ => ()
   end.
@@ -32,6 +32,6 @@ Goal True.
          do 5 pose c).
   Time let v := Control.hyps () in
        let i := @x in
-       iter (fun (h, body, ty) => find i ty; match body with Some b => find i b | None => () end) v.
+       iter (fun (_h, body, ty) => find i ty; match body with Some b => find i b | None => () end) v.
   (* Finished transaction in 0.75 secs *)
 Abort.

--- a/tests/compiler_bug_29.v
+++ b/tests/compiler_bug_29.v
@@ -1,0 +1,7 @@
+Require Import Ltac2.Ltac2.
+Require Import Ltac2Compiler.Ltac2Compiler.
+
+Ltac2 foo := let rec foo () := foo () in foo.
+
+Ltac2 Compile foo.
+(* Error: Anomaly "File "src/tac2compile.ml", line 662, characters 2-8: Assertion failed." *)

--- a/tests/tac2compile_test.v
+++ b/tests/tac2compile_test.v
@@ -189,7 +189,7 @@ Module MatchGoal.
 
   Ltac2 check () :=
     lazy_match! goal with
-    | [ h1 : context c1 [ ?t1 ] , h2 := context c2 [ Nat.add ?v2 ] , h3 : context c3 [ ?t2 ] |- _ ] =>
+    | [ _h1 : context c1 [ ?t1 ] , _h2 := context c2 [ Nat.add ?v2 ] , _h3 : context c3 [ ?t2 ] |- _ ] =>
         check_constr t1 'bool;
         check_constr v2 '0;
         check_constr t2 'bool;


### PR DESCRIPTION
Fix #29 